### PR TITLE
fix: reboot must be to post, at least to limit call errors.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -613,7 +613,7 @@ async def shutdownSUNSCAN():
     os.system("sudo shutdown -h now")
     return JSONResponse(content={"message": "Shutdown ok"}, status_code=200)
 
-@app.get("/sunscan/reboot", response_class=JSONResponse)
+@app.post("/sunscan/reboot", response_class=JSONResponse)
 async def rebootSUNSCAN():
     os.system("sudo shutdown -r now")
     return JSONResponse(content={"message": "Reboot ok"}, status_code=200)


### PR DESCRIPTION
HTTP have some verbe with a definition. Usualy, GET is for real-only method. All method whose change the state of server must be POST/PUT/PATCH/DELETE.